### PR TITLE
Update outdated modules to current

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -7,13 +7,13 @@ forge "https://forgeapi.puppetlabs.com"
 # modules from the puppet forge
 mod 'puppetlabs/stdlib', '4.5.1'
 mod 'puppetlabs/mysql', '3.3.0'
-mod 'puppetlabs/apache', '1.3.0'
-mod 'puppetlabs/rabbitmq', '5.0.0'
+mod 'puppetlabs/apache', '1.4.0'
+mod 'puppetlabs/rabbitmq', '5.1.0'
 mod 'puppetlabs/vcsrepo', '1.2.0'
-mod 'jfryman/nginx', '0.2.2'
+mod 'jfryman/nginx', '0.2.6'
 
 # Jenkins Dependencies
-mod 'puppetlabs/apt', '1.7.0'
+mod 'puppetlabs/apt', '1.8.0'
 mod 'puppetlabs/java','1.3.0'
 mod 'darin/zypprepo', '1.0.2'
 # Jenkins itself
@@ -21,9 +21,9 @@ mod 'rtyler/jenkins', '1.3.0'
 
 mod 'ajcrowe/supervisord', '0.5.2'
 mod 'torrancew/cron', '0.1.0'
-mod 'jbeard/nfs', '0.1.8'
+mod 'jbeard/nfs', '0.1.9'
 
-mod 'stankevich/python', '1.8.3'
+mod 'stankevich/python', '1.9.1'
 
 mod 'KyleAnderson/consul',
     :git => 'https://github.com/solarkennedy/puppet-consul.git'

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ No puppet modules should be in this repository, instead modules should be added 
 
 Install everything locally
 --------------------------
-```
+```bash
 git clone https://github.com/mozilla/nubis-puppet
 cd nubis-puppet
 librarian-puppet install --verbose
@@ -13,6 +13,21 @@ librarian-puppet install --verbose
 Librarian-puppet
 ----------------
 All modules are pulled in via `Puppetfiles` which are processed by [librarian-puppet](http://librarian-puppet.com/). If you make a change to any `Puppetfile` you are advised to run `librarian-puppet install --verbose` to ensure librarian-puppet can resolve any new dependencies.
+
+To find outdated dependancied
+```bash
+librarian-puppet outdated
+```
+
+To update an outdated module bump the version in the module file
+```bash
+vi Puppetfile
+librarian-puppet update
+git diff Puppetfile
+git add Puppetfile
+git commit -m "Bump the version of apache to 1.4.0."
+```
+
 
 r10k
 ----


### PR DESCRIPTION
Updated the readme with instructions for updating outdated modules

The following modules were updated:
jbeard/nfs (0.1.8 -> 0.1.9)
jfryman/nginx (0.2.2 -> 0.2.6)
puppetlabs/apache (1.3.0 -> 1.4.0)
puppetlabs/apt (1.7.0 -> 1.8.0)
puppetlabs/rabbitmq (5.0.0 -> 5.1.0)
stankevich/python (1.8.3 -> 1.9.1)